### PR TITLE
I1

### DIFF
--- a/lib/connectors/connectorExt.js
+++ b/lib/connectors/connectorExt.js
@@ -37,12 +37,21 @@ var async = require('async');
 var cloudant = require('../storage/storage');
 var recordTransformer = require("../transform/recordTransformer");
 var pipesDb = require("../storage/pipeStorage");
+var bluemixHelperConfig = require('bluemix-helper-config');
 
 function connectorExt(id, label, options){
 	options = options || {};
 	if ( !options.hasOwnProperty("copyToDashDb") ){
-		options.copyToDashDb = true;
+		options.copyToDashDb = false;
 	}
+	else {
+		if(!bluemixHelperConfig.vcapServices.getService( "dashdb" ) || (!bluemixHelperConfig.vcapServices.getService( "dataworks" ))) {
+			// the prerequiste services for data movement to dashDB are not bound to this application
+			// disable the feature
+			options.copyToDashDb = false;
+		}	
+	}
+
 	if ( !options.hasOwnProperty("recreateTargetDb") ){
 		options.recreateTargetDb = true;
 	}

--- a/lib/connectors/connectorExt.js
+++ b/lib/connectors/connectorExt.js
@@ -42,14 +42,13 @@ var bluemixHelperConfig = require('bluemix-helper-config');
 function connectorExt(id, label, options){
 	options = options || {};
 	if ( !options.hasOwnProperty("copyToDashDb") ){
-		options.copyToDashDb = false;
+		options.copyToDashDb = true;
 	}
-	else {
-		if(!bluemixHelperConfig.vcapServices.getService( "dashdb" ) || (!bluemixHelperConfig.vcapServices.getService( "dataworks" ))) {
+
+	if(!bluemixHelperConfig.vcapServices.getService( "dashdb" ) || (!bluemixHelperConfig.vcapServices.getService( "dataworks" ))) {
 			// the prerequiste services for data movement to dashDB are not bound to this application
 			// disable the feature
 			options.copyToDashDb = false;
-		}	
 	}
 
 	if ( !options.hasOwnProperty("recreateTargetDb") ){


### PR DESCRIPTION
Complements https://github.com/ibm-cds-labs/simple-data-pipe/pull/1. Data movement to dashDB is disabled if the dataworks service or the dashdb service is not bound to the simple data pipe application.

Note that the default behavior ("move data to dashDB if the connector did not specify an option" ) was retained to avoid breaking the legacy application.
